### PR TITLE
Corrige bind que resolve o client guzzle para o ApiFiles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "sysvale/api-files",
     "description": "A library to abstract communication with api-files",
     "type": "library",

--- a/src/ApiFiles.php
+++ b/src/ApiFiles.php
@@ -1,17 +1,16 @@
 <?php
 
-namespace jedsonmelo\ApiFiles;
+namespace Sysvale\ApiFiles;
 
-use GuzzleHttp\Client as Guzzle;
+use Sysvale\ApiFiles\ApiFilesClient;
 use Dotenv\Exception\InvalidFileException;
-use GuzzleHttp\ClientInterface;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class ApiFiles
 {
 	private $guzzle;
 
-	public function __construct(ClientInterface $guzzle)
+	public function __construct(ApiFilesClient $guzzle)
 	{
 		$this->guzzle = $guzzle;
 	}

--- a/src/ApiFilesClient.php
+++ b/src/ApiFilesClient.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Sysvale\ApiFiles;
+
+use GuzzleHttp\Client;
+
+class ApiFilesClient extends Client
+{
+}

--- a/src/ApiFilesServiceProvider.php
+++ b/src/ApiFilesServiceProvider.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace jedsonmelo\ApiFiles;
+namespace Sysvale\ApiFiles;
 
-use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Client as Guzzle;
+use Sysvale\ApiFiles\ApiFilesClient;
 use Illuminate\Support\ServiceProvider;
 
 class ApiFilesServiceProvider extends ServiceProvider
@@ -31,10 +30,10 @@ class ApiFilesServiceProvider extends ServiceProvider
 
 	protected function registerFacades()
 	{
-		$this->app->bind(ClientInterface::class, function ($app) {
+		$this->app->bind(ApiFilesClient::class, function ($app) {
 			$access_token = config('apifiles.access_token');
 
-			return new Guzzle([
+			return new ApiFilesClient([
 				'base_uri' => config('apifiles.url'),
 				'headers' => [
 					'Authorization' => "Bearer $access_token",

--- a/src/Facades/ApiFiles.php
+++ b/src/Facades/ApiFiles.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace jedsonmelo\ApiFiles\Facades;
+namespace Sysvale\ApiFiles\Facades;
 
 use Illuminate\Support\Facades\Facade;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace jedsonmelo\ApiFiles\Tests;
+namespace Sysvale\ApiFiles\Tests;
 
-use jedsonmelo\ApiFiles\ApiFilesServiceProvider;
+use Sysvale\ApiFiles\ApiFilesServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {


### PR DESCRIPTION
Ao resolver o client do guzzle direto a biblioteca tava recebendo o guzzle incorreto, provavelmente porque na aplicação existia algum outro bind em outro provider.